### PR TITLE
Add dark mode and new animations

### DIFF
--- a/public/theme.js
+++ b/public/theme.js
@@ -1,0 +1,22 @@
+(function () {
+  const updateIcon = (theme) => {
+    const icon = document.getElementById('theme-icon');
+    if (!icon) return;
+    icon.className = theme === 'dark' ? 'fas fa-sun' : 'fas fa-moon';
+  };
+
+  const setTheme = (theme) => {
+    document.documentElement.setAttribute('data-theme', theme);
+    localStorage.setItem('theme', theme);
+    updateIcon(theme);
+  };
+
+  const stored = localStorage.getItem('theme');
+  const prefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
+  setTheme(stored || (prefersDark ? 'dark' : 'light'));
+
+  window.toggleTheme = function () {
+    const current = document.documentElement.getAttribute('data-theme');
+    setTheme(current === 'dark' ? 'light' : 'dark');
+  };
+})();

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -45,3 +45,5 @@ const { title, description, image = '/blog-placeholder-1.jpg' } = Astro.props;
 <meta property="twitter:title" content={title} />
 <meta property="twitter:description" content={description} />
 <meta property="twitter:image" content={new URL(image, Astro.url)} />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" />
+<script src="/theme.js" defer></script>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -36,7 +36,14 @@ const today = new Date();
 		text-decoration: none;
 		color: rgb(var(--gray));
 	}
-	.social-links a:hover {
-		color: rgb(var(--gray-dark));
-	}
+        .social-links a:hover {
+                color: rgb(var(--gray-dark));
+        }
+        html[data-theme='dark'] footer {
+                background: linear-gradient(#1f2937, #0f172a) no-repeat;
+                color: rgb(var(--gray-dark));
+        }
+        html[data-theme='dark'] .social-links a {
+                color: rgb(var(--gray-dark));
+        }
 </style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -3,7 +3,7 @@ import HeaderLink from './HeaderLink.astro';
 import { SITE_TITLE } from '../consts';
 ---
 
-<header>
+<header class="animate__animated animate__fadeInDown">
 	<nav>
 		<h2><a href="/">{SITE_TITLE}</a></h2>
 		<div class="internal-links">
@@ -23,12 +23,12 @@ import { SITE_TITLE } from '../consts';
 	</nav>
 </header>
 <style>
-	header {
-		margin: 0;
-		padding: 0 1em;
-		background: white;
-		box-shadow: 0 2px 8px rgba(var(--black), 5%);
-	}
+        header {
+                margin: 0;
+                padding: 0 1em;
+                background: var(--header-bg, white);
+                box-shadow: 0 2px 8px rgba(var(--black), 5%);
+        }
 	h2 {
 		margin: 0;
 		font-size: 1em;
@@ -43,12 +43,12 @@ import { SITE_TITLE } from '../consts';
 		align-items: center;
 		justify-content: space-between;
 	}
-	nav a {
-		padding: 1em 0.5em;
-		color: var(--black);
-		border-bottom: 4px solid transparent;
-		text-decoration: none;
-	}
+        nav a {
+                padding: 1em 0.5em;
+                color: var(--header-link-color, var(--black));
+                border-bottom: 4px solid transparent;
+                text-decoration: none;
+        }
 	nav a.active {
 		text-decoration: none;
 		border-bottom-color: var(--accent);
@@ -64,11 +64,16 @@ import { SITE_TITLE } from '../consts';
 	.social-links a:last-child {
 		margin-right: 0;
 	}
-	@media (max-width: 720px) {
-		.social-links {
-			display: none;
-		}
-	}
+        @media (max-width: 720px) {
+                .social-links {
+                        display: none;
+                }
+        }
+
+        html[data-theme='dark'] header {
+                --header-bg: #1f2937;
+                --header-link-color: #f9fafb;
+        }
 </style>
 <!-- Add Font Awesome if not already loaded globally -->
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -26,6 +26,14 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
         --shadow: 0 2px 6px rgba(0, 0, 0, 0.06);
         --plasma-gradient: linear-gradient(90deg, #ff41ca, #5f007f, #2335be, #c321a5, #2af5ff);
       }
+      [data-theme='dark'] {
+        --text: #e5e7eb;
+        --text-light: #9ca3af;
+        --bg: #0f172a;
+        --card: #1f2937;
+        --border: #334155;
+        --shadow: 0 2px 6px rgba(0,0,0,0.6);
+      }
 
       body {
         font-family: 'Inter', sans-serif;
@@ -126,7 +134,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
   <body>
     <Header />
     <main>
-      <section id="about-server">
+      <section id="about-server" class="animate__animated animate__fadeInUp">
         <h2 class="section-title fade-in-section">About Us</h2>
         <div class="about-description fade-in-section">
           We've been providing high-quality cheats and private builds since <b>Black Ops Cold War</b> (2020), 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,7 +8,6 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
 <html lang="en">
   <head>
     <BaseHead title={SITE_TITLE} description={SITE_DESCRIPTION} />
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/animate.css/4.1.1/animate.min.css" />
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -25,6 +24,14 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
         --radius: 18px;
         --shadow: 0 4px 24px rgba(99,102,241,0.13);
         --plasma-gradient: linear-gradient(90deg, #ff41ca, #5f007f, #2335be, #c321a5, #2af5ff);
+      }
+      [data-theme='dark'] {
+        --text: #e5e7eb;
+        --text-light: #9ca3af;
+        --bg: #0f172a;
+        --card: #1f2937;
+        --border: #334155;
+        --shadow: 0 4px 24px rgba(0,0,0,0.6);
       }
       body {
         font-family: 'Inter', sans-serif;
@@ -274,7 +281,7 @@ import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
     <Header />
     <main>
       <!-- HERO SECTION -->
-      <section class="hero animate-on-scroll">
+      <section class="hero animate-on-scroll animate__animated animate__fadeInUp">
         <div class="hero-bg"></div>
         <img
           src="https://files.catbox.moe/nw8y4u.png"

--- a/src/pages/shop/index.astro
+++ b/src/pages/shop/index.astro
@@ -39,6 +39,14 @@ try {
         --card-blur: blur(18px);
         --transition: all 0.36s cubic-bezier(.47,1.64,.41,.8);
       }
+      [data-theme='dark'] {
+        --bg: #0f172a;
+        --text: #e5e7eb;
+        --muted: #9ca3af;
+        --border: #334155;
+        --shadow: 0 8px 40px 0 rgba(0,0,0,0.6), 0 2px 8px rgba(0,0,0,0.5);
+        --glass: rgba(31,41,55,0.8);
+      }
 
       html, body {
         font-family: 'Inter', sans-serif;
@@ -272,7 +280,7 @@ try {
   <body>
     <Header />
     <main>
-      <section class="hero">
+      <section class="hero animate__animated animate__fadeInUp">
         <div class="hero-blobs" aria-hidden="true">
           <!-- Animated SVG blobs for modern look -->
           <svg width="100%" height="100%" viewBox="0 0 800 400" style="position:absolute;top:0;left:0;" xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
## Summary
- implement client-side theme toggle with `theme.js`
- load global animations and theme script in `<BaseHead>`
- animate header and hero sections
- improve footer and header styles for dark mode
- add dark color variables for each page

## Testing
- `npm run check` *(fails: astro not found)*

------
https://chatgpt.com/codex/tasks/task_e_68433214d34083308ba1085cd5372169